### PR TITLE
temporarily combine chrom before building bt2 index in allelic mode

### DIFF
--- a/snakePipes/shared/rules/masked_genomeIndex.snakefile
+++ b/snakePipes/shared/rules/masked_genomeIndex.snakefile
@@ -84,18 +84,18 @@ if aligner == "STAR":
 elif aligner == "Bowtie2":
     rule bowtie2_index:
         input:
-            snpgenome_dir = SNPdir#,
-#            filelist = lambda wildcards: getref_fileList(checkpoints.create_snpgenome.get().output.snpgenome_dir)
+            snpgenome_dir = SNPdir
         output:
-            bowtie2_index_allelic
+            btix = bowtie2_index_allelic,
+            tmpfna = temp("snp_genome/concat.fna")
         threads: lambda wildcards: 10 if 10<max_thread else max_thread
         params:
             idxbase = "snp_genome/bowtie2_Nmasked/Genome"
         conda: CONDA_DNA_MAPPING_ENV
-        shell:
-            "bowtie2-build"
-            " --threads {threads}"
-            " {input.snpgenome_dir}/*.fa"
-            " {params.idxbase}"
+        shell:'''                                                                                                                            
+        cat {input.snpgenome_dir}/*.fa > {output.tmpfna}
+        bowtie2-build --threads {threads} \
+           {output.tmpfna} {params.idxbase}
+        ''' 
 else:
     print("Only STAR and Bowtie2 are implemented for allele-specific mapping")


### PR DESCRIPTION
Having an index built when passing --VCFfile combined with --strains can result in a genome directory with hundreds (or thousands) of files. This triggered an argument length error due to how the command is passed to bowtie2-index command. Temporarily catting the files together is a work-around, as it's not actually a file limit but some other OS limit internal to subprocess and/or snakemake